### PR TITLE
update(qos): support foreign ip whitelist.

### DIFF
--- a/dubbo-common/src/main/java/org/apache/dubbo/common/constants/QosConstants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/common/constants/QosConstants.java
@@ -30,6 +30,8 @@ public interface QosConstants {
 
     String ACCEPT_FOREIGN_IP = "qos.accept.foreign.ip";
 
+    String ACCEPT_FOREIGN_IP_WHITELIST = "qos.accept.foreign.ip.whitelist";
+
     String QOS_ENABLE_COMPATIBLE = "qos-enable";
 
     String QOS_HOST_COMPATIBLE = "qos-host";
@@ -37,4 +39,6 @@ public interface QosConstants {
     String QOS_PORT_COMPATIBLE = "qos-port";
 
     String ACCEPT_FOREIGN_IP_COMPATIBLE = "qos-accept-foreign-ip";
+
+    String ACCEPT_FOREIGN_IP_WHITELIST_COMPATIBLE = "qos-accept-foreign-ip-whitelist";
 }

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ApplicationConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ApplicationConfig.java
@@ -50,6 +50,8 @@ import static org.apache.dubbo.common.constants.CommonConstants.STARTUP_PROBE;
 import static org.apache.dubbo.common.constants.LoggerCodeConstants.COMMON_UNEXPECTED_EXCEPTION;
 import static org.apache.dubbo.common.constants.QosConstants.ACCEPT_FOREIGN_IP;
 import static org.apache.dubbo.common.constants.QosConstants.ACCEPT_FOREIGN_IP_COMPATIBLE;
+import static org.apache.dubbo.common.constants.QosConstants.ACCEPT_FOREIGN_IP_WHITELIST;
+import static org.apache.dubbo.common.constants.QosConstants.ACCEPT_FOREIGN_IP_WHITELIST_COMPATIBLE;
 import static org.apache.dubbo.common.constants.QosConstants.QOS_ENABLE;
 import static org.apache.dubbo.common.constants.QosConstants.QOS_ENABLE_COMPATIBLE;
 import static org.apache.dubbo.common.constants.QosConstants.QOS_HOST;
@@ -148,6 +150,11 @@ public class ApplicationConfig extends AbstractConfig {
      * Should we accept foreign ip or not?
      */
     private Boolean qosAcceptForeignIp;
+
+    /**
+     * When we disable accept foreign ip, support specify foreign ip in the whitelist
+     */
+    private String qosAcceptForeignIpWhitelist;
 
     /**
      * Customized parameters
@@ -400,6 +407,15 @@ public class ApplicationConfig extends AbstractConfig {
         this.qosAcceptForeignIp = qosAcceptForeignIp;
     }
 
+    @Parameter(key = ACCEPT_FOREIGN_IP_WHITELIST)
+    public String getQosAcceptForeignIpWhitelist() {
+        return qosAcceptForeignIpWhitelist;
+    }
+
+    public void setQosAcceptForeignIpWhitelist(String qosAcceptForeignIpWhitelist) {
+        this.qosAcceptForeignIpWhitelist = qosAcceptForeignIpWhitelist;
+    }
+
     /**
      * The format is the same as the springboot, including: getQosEnableCompatible(), getQosPortCompatible(), getQosAcceptForeignIpCompatible().
      *
@@ -439,6 +455,15 @@ public class ApplicationConfig extends AbstractConfig {
 
     public void setQosAcceptForeignIpCompatible(Boolean qosAcceptForeignIp) {
         this.setQosAcceptForeignIp(qosAcceptForeignIp);
+    }
+
+    @Parameter(key = ACCEPT_FOREIGN_IP_WHITELIST_COMPATIBLE, excluded = true, attribute = false)
+    public String getQosAcceptForeignIpWhitelistCompatible() {
+        return qosAcceptForeignIpWhitelist;
+    }
+
+    public void setQosAcceptForeignIpWhitelistCompatible(String qosAcceptForeignIpWhiteList) {
+        this.qosAcceptForeignIpWhitelist = qosAcceptForeignIpWhiteList;
     }
 
     public Map<String, String> getParameters() {

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ApplicationConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ApplicationConfig.java
@@ -459,11 +459,11 @@ public class ApplicationConfig extends AbstractConfig {
 
     @Parameter(key = ACCEPT_FOREIGN_IP_WHITELIST_COMPATIBLE, excluded = true, attribute = false)
     public String getQosAcceptForeignIpWhitelistCompatible() {
-        return qosAcceptForeignIpWhitelist;
+        return this.getQosAcceptForeignIpWhitelist();
     }
 
     public void setQosAcceptForeignIpWhitelistCompatible(String qosAcceptForeignIpWhitelist) {
-        this.qosAcceptForeignIpWhitelist = qosAcceptForeignIpWhitelist;
+        this.setQosAcceptForeignIpWhitelist(qosAcceptForeignIpWhitelist);
     }
 
     public Map<String, String> getParameters() {

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/ApplicationConfig.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/ApplicationConfig.java
@@ -462,8 +462,8 @@ public class ApplicationConfig extends AbstractConfig {
         return qosAcceptForeignIpWhitelist;
     }
 
-    public void setQosAcceptForeignIpWhitelistCompatible(String qosAcceptForeignIpWhiteList) {
-        this.qosAcceptForeignIpWhitelist = qosAcceptForeignIpWhiteList;
+    public void setQosAcceptForeignIpWhitelistCompatible(String qosAcceptForeignIpWhitelist) {
+        this.qosAcceptForeignIpWhitelist = qosAcceptForeignIpWhitelist;
     }
 
     public Map<String, String> getParameters() {

--- a/dubbo-common/src/main/java/org/apache/dubbo/config/Constants.java
+++ b/dubbo-common/src/main/java/org/apache/dubbo/config/Constants.java
@@ -18,6 +18,7 @@
 package org.apache.dubbo.config;
 
 import static org.apache.dubbo.common.constants.QosConstants.ACCEPT_FOREIGN_IP_COMPATIBLE;
+import static org.apache.dubbo.common.constants.QosConstants.ACCEPT_FOREIGN_IP_WHITELIST_COMPATIBLE;
 import static org.apache.dubbo.common.constants.QosConstants.QOS_ENABLE_COMPATIBLE;
 import static org.apache.dubbo.common.constants.QosConstants.QOS_HOST_COMPATIBLE;
 import static org.apache.dubbo.common.constants.QosConstants.QOS_PORT_COMPATIBLE;
@@ -140,7 +141,7 @@ public interface Constants {
     String MULTI_SERIALIZATION_KEY = "serialize.multiple";
 
     String[] DOT_COMPATIBLE_KEYS = new String[]{QOS_ENABLE_COMPATIBLE, QOS_HOST_COMPATIBLE, QOS_PORT_COMPATIBLE,
-        ACCEPT_FOREIGN_IP_COMPATIBLE, REGISTRY_TYPE_KEY};
+        ACCEPT_FOREIGN_IP_COMPATIBLE, ACCEPT_FOREIGN_IP_WHITELIST_COMPATIBLE, REGISTRY_TYPE_KEY};
 
     String IGNORE_CHECK_KEYS = "ignoreCheckKeys";
 

--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/protocol/QosProtocolWrapper.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/protocol/QosProtocolWrapper.java
@@ -20,6 +20,7 @@ import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.Activate;
 import org.apache.dubbo.common.logger.ErrorTypeAwareLogger;
 import org.apache.dubbo.common.logger.LoggerFactory;
+import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.qos.common.QosConstants;
 import org.apache.dubbo.qos.pu.QosWireProtocol;
 import org.apache.dubbo.qos.server.Server;
@@ -37,6 +38,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 
 import static org.apache.dubbo.common.constants.LoggerCodeConstants.QOS_FAILED_START_SERVER;
 import static org.apache.dubbo.common.constants.QosConstants.ACCEPT_FOREIGN_IP;
+import static org.apache.dubbo.common.constants.QosConstants.ACCEPT_FOREIGN_IP_WHITELIST;
 import static org.apache.dubbo.common.constants.QosConstants.QOS_ENABLE;
 import static org.apache.dubbo.common.constants.QosConstants.QOS_HOST;
 import static org.apache.dubbo.common.constants.QosConstants.QOS_PORT;
@@ -113,6 +115,7 @@ public class QosProtocolWrapper implements Protocol, ScopeModelAware {
             String host = url.getParameter(QOS_HOST);
             int port = url.getParameter(QOS_PORT, QosConstants.DEFAULT_PORT);
             boolean acceptForeignIp = Boolean.parseBoolean(url.getParameter(ACCEPT_FOREIGN_IP, "false"));
+            String acceptForeignIpWhitelist = url.getParameter(ACCEPT_FOREIGN_IP_WHITELIST, StringUtils.EMPTY_STRING);
             Server server = frameworkModel.getBeanFactory().getBean(Server.class);
 
             if (server.isStarted()) {
@@ -122,6 +125,7 @@ public class QosProtocolWrapper implements Protocol, ScopeModelAware {
             server.setHost(host);
             server.setPort(port);
             server.setAcceptForeignIp(acceptForeignIp);
+            server.setAcceptForeignIpWhitelist(acceptForeignIpWhitelist);
             server.start();
 
         } catch (Throwable throwable) {

--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/pu/QosWireProtocol.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/pu/QosWireProtocol.java
@@ -18,6 +18,7 @@ package org.apache.dubbo.qos.pu;
 
 import org.apache.dubbo.common.URL;
 import org.apache.dubbo.common.extension.Activate;
+import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.qos.server.DubboLogo;
 import org.apache.dubbo.qos.server.handler.QosProcessHandler;
 import org.apache.dubbo.remoting.ChannelHandler;
@@ -48,7 +49,7 @@ public class QosWireProtocol extends AbstractWireProtocol implements ScopeModelA
     public void configServerProtocolHandler(URL url, ChannelOperator operator) {
         // add qosProcess handler
         QosProcessHandler handler = new QosProcessHandler(url.getOrDefaultFrameworkModel(),
-            DubboLogo.DUBBO, false);
+            DubboLogo.DUBBO, false, StringUtils.EMPTY_STRING);
         List<ChannelHandler> handlers = new ArrayList<>();
         handlers.add(new ChannelHandlerPretender(handler));
         operator.configChannelHandler(handlers);

--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/server/Server.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/server/Server.java
@@ -52,6 +52,7 @@ public class Server {
     private int port;
 
     private boolean acceptForeignIp = true;
+    private String acceptForeignIpWhitelist = StringUtils.EMPTY_STRING;
 
     private EventLoopGroup boss;
 
@@ -97,7 +98,7 @@ public class Server {
 
             @Override
             protected void initChannel(Channel ch) throws Exception {
-                ch.pipeline().addLast(new QosProcessHandler(frameworkModel, welcome, acceptForeignIp));
+                ch.pipeline().addLast(new QosProcessHandler(frameworkModel, welcome, acceptForeignIp, acceptForeignIpWhitelist));
             }
         });
         try {
@@ -145,6 +146,10 @@ public class Server {
 
     public void setAcceptForeignIp(boolean acceptForeignIp) {
         this.acceptForeignIp = acceptForeignIp;
+    }
+
+    public void setAcceptForeignIpWhitelist(String acceptForeignIpWhitelist) {
+        this.acceptForeignIpWhitelist = acceptForeignIpWhitelist;
     }
 
     public String getWelcome() {

--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/server/handler/ForeignHostPermitHandler.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/server/handler/ForeignHostPermitHandler.java
@@ -21,7 +21,7 @@ import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerAdapter;
 import io.netty.channel.ChannelHandlerContext;
-import org.apache.dubbo.common.utils.CIDRUtils;
+import org.apache.dubbo.common.utils.NetUtils;
 import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.qos.common.QosConstants;
 
@@ -31,7 +31,7 @@ import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.function.Predicate;
 
-public class LocalHostPermitHandler extends ChannelHandlerAdapter {
+public class ForeignHostPermitHandler extends ChannelHandlerAdapter {
 
     // true means to accept foreign IP
     private  boolean acceptForeignIp;
@@ -41,7 +41,7 @@ public class LocalHostPermitHandler extends ChannelHandlerAdapter {
     private String acceptForeignIpWhitelist;
     private Predicate<String> whitelistPredicate = foreignIp -> false;
 
-    public LocalHostPermitHandler(boolean acceptForeignIp, String foreignIpWhitelist) {
+    public ForeignHostPermitHandler(boolean acceptForeignIp, String foreignIpWhitelist) {
         this.acceptForeignIp = acceptForeignIp;
         this.acceptForeignIpWhitelist = foreignIpWhitelist;
         if (StringUtils.isNotEmpty(foreignIpWhitelist)) {
@@ -53,7 +53,8 @@ public class LocalHostPermitHandler extends ChannelHandlerAdapter {
                         if (!item.contains("/")) {
                             return StringUtils.isEquals(item, foreignIp);
                         }
-                        return new CIDRUtils(item).isInRange(foreignIp);
+                        // hard code port to -1, support ip range from CIDR specification only
+                        return NetUtils.matchIpExpression(item, foreignIp, -1);
                     } catch (UnknownHostException ignore) {
                         // ignore illegal CIDR specification
                     }

--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/server/handler/ForeignHostPermitHandler.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/server/handler/ForeignHostPermitHandler.java
@@ -48,13 +48,10 @@ public class ForeignHostPermitHandler extends ChannelHandlerAdapter {
             whitelistPredicate = Arrays.stream(foreignIpWhitelist.split(","))
                 .map(String::trim)
                 .filter(StringUtils::isNotEmpty)
-                .map(item -> (Predicate<String>) (foreignIp) -> {
+                .map(foreignIpPattern -> (Predicate<String>) (foreignIp) -> {
                     try {
-                        if (!item.contains("/")) {
-                            return StringUtils.isEquals(item, foreignIp);
-                        }
-                        // hard code port to -1, support ip range from CIDR specification only
-                        return NetUtils.matchIpExpression(item, foreignIp, -1);
+                        // hard code port to -1
+                        return NetUtils.matchIpExpression(foreignIpPattern, foreignIp, -1);
                     } catch (UnknownHostException ignore) {
                         // ignore illegal CIDR specification
                     }

--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/server/handler/ForeignHostPermitHandler.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/server/handler/ForeignHostPermitHandler.java
@@ -48,7 +48,7 @@ public class ForeignHostPermitHandler extends ChannelHandlerAdapter {
             whitelistPredicate = Arrays.stream(foreignIpWhitelist.split(","))
                 .map(String::trim)
                 .filter(StringUtils::isNotEmpty)
-                .map(foreignIpPattern -> (Predicate<String>) (foreignIp) -> {
+                .map(foreignIpPattern -> (Predicate<String>) foreignIp -> {
                     try {
                         // hard code port to -1
                         return NetUtils.matchIpExpression(foreignIpPattern, foreignIp, -1);

--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/server/handler/LocalHostPermitHandler.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/server/handler/LocalHostPermitHandler.java
@@ -16,33 +16,76 @@
  */
 package org.apache.dubbo.qos.server.handler;
 
-import org.apache.dubbo.qos.common.QosConstants;
-
 import io.netty.buffer.ByteBuf;
 import io.netty.buffer.Unpooled;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerAdapter;
 import io.netty.channel.ChannelHandlerContext;
+import org.apache.dubbo.common.utils.StringUtils;
+import org.apache.dubbo.qos.common.QosConstants;
 
+import java.net.InetAddress;
 import java.net.InetSocketAddress;
+import java.util.Arrays;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
 
 public class LocalHostPermitHandler extends ChannelHandlerAdapter {
 
     // true means to accept foreign IP
     private  boolean acceptForeignIp;
 
-    public LocalHostPermitHandler(boolean acceptForeignIp) {
+    // the whitelist of foreign IP when acceptForeignIp = false, separated by semicolon(;)
+    // if the whitelist item start with `~`, treat it as escaped regex string
+    private String acceptForeignIpWhitelist;
+    private Predicate<String> whitelistPredicate = foreignIp -> false;
+
+    public LocalHostPermitHandler(boolean acceptForeignIp, String foreignIpWhiteList) {
         this.acceptForeignIp = acceptForeignIp;
+        this.acceptForeignIpWhitelist = foreignIpWhiteList;
+        if (StringUtils.isNotEmpty(foreignIpWhiteList)) {
+            whitelistPredicate = Arrays.stream(foreignIpWhiteList.split(";"))
+                .map(String::trim)
+                .filter(StringUtils::isNotEmpty)
+                .map(item -> (Predicate<String>) (foreignIp) -> {
+                    if (!item.startsWith("~")) {
+                        return StringUtils.isEquals(item, foreignIp);
+                    }
+                    // if the whitelist item start with `~`, treat it as regex
+                    return Pattern.compile(item.substring(1)).matcher(foreignIp).matches();
+                })
+                .reduce(Predicate::or).orElse(s -> false);
+        }
     }
 
     @Override
     public void handlerAdded(ChannelHandlerContext ctx) throws Exception {
-        if (!acceptForeignIp) {
-            if (!((InetSocketAddress) ctx.channel().remoteAddress()).getAddress().isLoopbackAddress()) {
-                ByteBuf cb = Unpooled.wrappedBuffer((QosConstants.BR_STR + "Foreign Ip Not Permitted."
-                        + QosConstants.BR_STR).getBytes());
-                ctx.writeAndFlush(cb).addListener(ChannelFutureListener.CLOSE);
-            }
+        if (acceptForeignIp) {
+            return;
         }
+
+        final InetAddress inetAddress = ((InetSocketAddress) ctx.channel().remoteAddress()).getAddress();
+        // loopback address, return
+        if (inetAddress.isLoopbackAddress()) {
+            return;
+        }
+
+        // the ip is in the whitelist, return
+        if (checkForeignIpInWhiteList(inetAddress)) {
+            return;
+        }
+
+        ByteBuf cb = Unpooled.wrappedBuffer((QosConstants.BR_STR + "Foreign Ip Not Permitted, Consider Config It In Whitelist."
+            + QosConstants.BR_STR).getBytes());
+        ctx.writeAndFlush(cb).addListener(ChannelFutureListener.CLOSE);
+    }
+
+    private boolean checkForeignIpInWhiteList(InetAddress inetAddress) {
+        if (StringUtils.isEmpty(acceptForeignIpWhitelist)) {
+            return false;
+        }
+
+        final String foreignIp = inetAddress.getHostAddress();
+        return whitelistPredicate.test(foreignIp);
     }
 }

--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/server/handler/LocalHostPermitHandler.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/server/handler/LocalHostPermitHandler.java
@@ -40,11 +40,11 @@ public class LocalHostPermitHandler extends ChannelHandlerAdapter {
     private String acceptForeignIpWhitelist;
     private Predicate<String> whitelistPredicate = foreignIp -> false;
 
-    public LocalHostPermitHandler(boolean acceptForeignIp, String foreignIpWhiteList) {
+    public LocalHostPermitHandler(boolean acceptForeignIp, String foreignIpWhitelist) {
         this.acceptForeignIp = acceptForeignIp;
-        this.acceptForeignIpWhitelist = foreignIpWhiteList;
-        if (StringUtils.isNotEmpty(foreignIpWhiteList)) {
-            whitelistPredicate = Arrays.stream(foreignIpWhiteList.split(";"))
+        this.acceptForeignIpWhitelist = foreignIpWhitelist;
+        if (StringUtils.isNotEmpty(foreignIpWhitelist)) {
+            whitelistPredicate = Arrays.stream(foreignIpWhitelist.split(";"))
                 .map(String::trim)
                 .filter(StringUtils::isNotEmpty)
                 .map(item -> (Predicate<String>) (foreignIp) -> {

--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/server/handler/QosProcessHandler.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/server/handler/QosProcessHandler.java
@@ -77,7 +77,7 @@ public class QosProcessHandler extends ByteToMessageDecoder {
         final int magic = in.getByte(in.readerIndex());
 
         ChannelPipeline p = ctx.pipeline();
-        p.addLast(new LocalHostPermitHandler(acceptForeignIp, acceptForeignIpWhitelist));
+        p.addLast(new ForeignHostPermitHandler(acceptForeignIp, acceptForeignIpWhitelist));
         if (isHttp(magic)) {
             // no welcome output for http protocol
             if (welcomeFuture != null && welcomeFuture.isCancellable()) {

--- a/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/server/handler/QosProcessHandler.java
+++ b/dubbo-plugin/dubbo-qos/src/main/java/org/apache/dubbo/qos/server/handler/QosProcessHandler.java
@@ -44,15 +44,17 @@ public class QosProcessHandler extends ByteToMessageDecoder {
     private String welcome;
     // true means to accept foreign IP
     private boolean acceptForeignIp;
+    private String acceptForeignIpWhitelist;
 
     private FrameworkModel frameworkModel;
 
     public static final String PROMPT = "dubbo>";
 
-    public QosProcessHandler(FrameworkModel frameworkModel, String welcome, boolean acceptForeignIp) {
+    public QosProcessHandler(FrameworkModel frameworkModel, String welcome, boolean acceptForeignIp, String acceptForeignIpWhitelist) {
         this.frameworkModel = frameworkModel;
         this.welcome = welcome;
         this.acceptForeignIp = acceptForeignIp;
+        this.acceptForeignIpWhitelist = acceptForeignIpWhitelist;
     }
 
     @Override
@@ -75,7 +77,7 @@ public class QosProcessHandler extends ByteToMessageDecoder {
         final int magic = in.getByte(in.readerIndex());
 
         ChannelPipeline p = ctx.pipeline();
-        p.addLast(new LocalHostPermitHandler(acceptForeignIp));
+        p.addLast(new LocalHostPermitHandler(acceptForeignIp, acceptForeignIpWhitelist));
         if (isHttp(magic)) {
             // no welcome output for http protocol
             if (welcomeFuture != null && welcomeFuture.isCancellable()) {

--- a/dubbo-plugin/dubbo-qos/src/test/java/org/apache/dubbo/qos/server/handler/ForeignHostPermitHandlerTest.java
+++ b/dubbo-plugin/dubbo-qos/src/test/java/org/apache/dubbo/qos/server/handler/ForeignHostPermitHandlerTest.java
@@ -36,7 +36,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-class LocalHostPermitHandlerTest {
+class ForeignHostPermitHandlerTest {
     @Test
     void shouldShowIpNotPermittedMsg_GivenAcceptForeignIpFalseAndEmptyWhiteList() throws Exception {
         ChannelHandlerContext context = mock(ChannelHandlerContext.class);
@@ -48,7 +48,7 @@ class LocalHostPermitHandlerTest {
         when(channel.remoteAddress()).thenReturn(address);
         ChannelFuture future = mock(ChannelFuture.class);
         when(context.writeAndFlush(any(ByteBuf.class))).thenReturn(future);
-        LocalHostPermitHandler handler = new LocalHostPermitHandler(false, StringUtils.EMPTY_STRING);
+        ForeignHostPermitHandler handler = new ForeignHostPermitHandler(false, StringUtils.EMPTY_STRING);
         handler.handlerAdded(context);
         ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
         verify(context).writeAndFlush(captor.capture());
@@ -68,7 +68,7 @@ class LocalHostPermitHandlerTest {
         when(channel.remoteAddress()).thenReturn(address);
         ChannelFuture future = mock(ChannelFuture.class);
         when(context.writeAndFlush(any(ByteBuf.class))).thenReturn(future);
-        LocalHostPermitHandler handler = new LocalHostPermitHandler(false, "175.23.44.1 ,  192.168.1.192/26");
+        ForeignHostPermitHandler handler = new ForeignHostPermitHandler(false, "175.23.44.1 ,  192.168.1.192/26");
         handler.handlerAdded(context);
         ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
         verify(context).writeAndFlush(captor.capture());
@@ -87,7 +87,7 @@ class LocalHostPermitHandlerTest {
         InetSocketAddress address = new InetSocketAddress(addr, 12345);
         when(channel.remoteAddress()).thenReturn(address);
 
-        LocalHostPermitHandler handler = new LocalHostPermitHandler(false, "175.23.44.1, 192.168.1.192/26  ");
+        ForeignHostPermitHandler handler = new ForeignHostPermitHandler(false, "175.23.44.1, 192.168.1.192/26  ");
         handler.handlerAdded(context);
         verify(context, never()).writeAndFlush(any());
     }
@@ -103,7 +103,7 @@ class LocalHostPermitHandlerTest {
         InetSocketAddress address = new InetSocketAddress(addr, 12345);
         when(channel.remoteAddress()).thenReturn(address);
 
-        LocalHostPermitHandler handler = new LocalHostPermitHandler(false, "175.23.44.1, 192.168.1.192/26");
+        ForeignHostPermitHandler handler = new ForeignHostPermitHandler(false, "175.23.44.1, 192.168.1.192/26");
         handler.handlerAdded(context);
         verify(context, never()).writeAndFlush(any());
     }

--- a/dubbo-plugin/dubbo-qos/src/test/java/org/apache/dubbo/qos/server/handler/LocalHostPermitHandlerTest.java
+++ b/dubbo-plugin/dubbo-qos/src/test/java/org/apache/dubbo/qos/server/handler/LocalHostPermitHandlerTest.java
@@ -21,6 +21,7 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelFutureListener;
 import io.netty.channel.ChannelHandlerContext;
+import org.apache.dubbo.common.utils.StringUtils;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
@@ -31,12 +32,13 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 class LocalHostPermitHandlerTest {
     @Test
-    void testHandlerAdded() throws Exception {
+    void shouldShowIpNotPermitted_GivenAcceptForeignIpFalseAndEmptyWhiteList() throws Exception {
         ChannelHandlerContext context = mock(ChannelHandlerContext.class);
         Channel channel = mock(Channel.class);
         when(context.channel()).thenReturn(channel);
@@ -46,11 +48,63 @@ class LocalHostPermitHandlerTest {
         when(channel.remoteAddress()).thenReturn(address);
         ChannelFuture future = mock(ChannelFuture.class);
         when(context.writeAndFlush(any(ByteBuf.class))).thenReturn(future);
-        LocalHostPermitHandler handler = new LocalHostPermitHandler(false);
+        LocalHostPermitHandler handler = new LocalHostPermitHandler(false, StringUtils.EMPTY_STRING);
         handler.handlerAdded(context);
         ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
         verify(context).writeAndFlush(captor.capture());
-        assertThat(new String(captor.getValue().array()), containsString("Foreign Ip Not Permitted"));
+        assertThat(new String(captor.getValue().array()), containsString("Foreign Ip Not Permitted, Consider Config It In Whitelist"));
         verify(future).addListener(ChannelFutureListener.CLOSE);
+    }
+
+    @Test
+    void shouldShowIpNotPermitted_GivenAcceptForeignIpFalseAndInvalidWhiteList() throws Exception {
+        ChannelHandlerContext context = mock(ChannelHandlerContext.class);
+        Channel channel = mock(Channel.class);
+        when(context.channel()).thenReturn(channel);
+        InetAddress addr = mock(InetAddress.class);
+        when(addr.isLoopbackAddress()).thenReturn(false);
+        when(addr.getHostAddress()).thenReturn("179.23.44.1");
+        InetSocketAddress address = new InetSocketAddress(addr, 12345);
+        when(channel.remoteAddress()).thenReturn(address);
+        ChannelFuture future = mock(ChannelFuture.class);
+        when(context.writeAndFlush(any(ByteBuf.class))).thenReturn(future);
+        LocalHostPermitHandler handler = new LocalHostPermitHandler(false, "175.23.44.1 ;  ~252.\\d{1,2}\\.\\d{1,2}\\.\\d{1,2}");
+        handler.handlerAdded(context);
+        ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
+        verify(context).writeAndFlush(captor.capture());
+        assertThat(new String(captor.getValue().array()), containsString("Foreign Ip Not Permitted, Consider Config It In Whitelist"));
+        verify(future).addListener(ChannelFutureListener.CLOSE);
+    }
+
+    @Test
+    void shouldNotShowIpNotPermitted_GivenAcceptForeignIpFalseAndValidWhiteList() throws Exception {
+        ChannelHandlerContext context = mock(ChannelHandlerContext.class);
+        Channel channel = mock(Channel.class);
+        when(context.channel()).thenReturn(channel);
+        InetAddress addr = mock(InetAddress.class);
+        when(addr.isLoopbackAddress()).thenReturn(false);
+        when(addr.getHostAddress()).thenReturn("175.23.44.1");
+        InetSocketAddress address = new InetSocketAddress(addr, 12345);
+        when(channel.remoteAddress()).thenReturn(address);
+
+        LocalHostPermitHandler handler = new LocalHostPermitHandler(false, "175.23.44.1;~171.\\d{1,3}\\.\\d{1,2}\\.\\d{1,3}  ");
+        handler.handlerAdded(context);
+        verify(context, never()).writeAndFlush(any());
+    }
+
+    @Test
+    void shouldNotShowIpNotPermitted_GivenAcceptForeignIpFalseAndValidWhiteListRegex() throws Exception {
+        ChannelHandlerContext context = mock(ChannelHandlerContext.class);
+        Channel channel = mock(Channel.class);
+        when(context.channel()).thenReturn(channel);
+        InetAddress addr = mock(InetAddress.class);
+        when(addr.isLoopbackAddress()).thenReturn(false);
+        when(addr.getHostAddress()).thenReturn("171.33.21.6");
+        InetSocketAddress address = new InetSocketAddress(addr, 12345);
+        when(channel.remoteAddress()).thenReturn(address);
+
+        LocalHostPermitHandler handler = new LocalHostPermitHandler(false, "175.23.44.1; ~171.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}");
+        handler.handlerAdded(context);
+        verify(context, never()).writeAndFlush(any());
     }
 }

--- a/dubbo-plugin/dubbo-qos/src/test/java/org/apache/dubbo/qos/server/handler/LocalHostPermitHandlerTest.java
+++ b/dubbo-plugin/dubbo-qos/src/test/java/org/apache/dubbo/qos/server/handler/LocalHostPermitHandlerTest.java
@@ -57,7 +57,7 @@ class LocalHostPermitHandlerTest {
     }
 
     @Test
-    void shouldShowIpNotPermittedMsg_GivenAcceptForeignIpFalseAndInvalidWhiteList() throws Exception {
+    void shouldShowIpNotPermittedMsg_GivenAcceptForeignIpFalseAndNotMatchWhiteList() throws Exception {
         ChannelHandlerContext context = mock(ChannelHandlerContext.class);
         Channel channel = mock(Channel.class);
         when(context.channel()).thenReturn(channel);
@@ -68,7 +68,7 @@ class LocalHostPermitHandlerTest {
         when(channel.remoteAddress()).thenReturn(address);
         ChannelFuture future = mock(ChannelFuture.class);
         when(context.writeAndFlush(any(ByteBuf.class))).thenReturn(future);
-        LocalHostPermitHandler handler = new LocalHostPermitHandler(false, "175.23.44.1 ;  ~252.\\d{1,2}\\.\\d{1,2}\\.\\d{1,2}");
+        LocalHostPermitHandler handler = new LocalHostPermitHandler(false, "175.23.44.1 ,  192.168.1.192/26");
         handler.handlerAdded(context);
         ArgumentCaptor<ByteBuf> captor = ArgumentCaptor.forClass(ByteBuf.class);
         verify(context).writeAndFlush(captor.capture());
@@ -77,7 +77,7 @@ class LocalHostPermitHandlerTest {
     }
 
     @Test
-    void shouldNotShowIpNotPermittedMsg_GivenAcceptForeignIpFalseAndValidWhiteList() throws Exception {
+    void shouldNotShowIpNotPermittedMsg_GivenAcceptForeignIpFalseAndMatchWhiteList() throws Exception {
         ChannelHandlerContext context = mock(ChannelHandlerContext.class);
         Channel channel = mock(Channel.class);
         when(context.channel()).thenReturn(channel);
@@ -87,23 +87,23 @@ class LocalHostPermitHandlerTest {
         InetSocketAddress address = new InetSocketAddress(addr, 12345);
         when(channel.remoteAddress()).thenReturn(address);
 
-        LocalHostPermitHandler handler = new LocalHostPermitHandler(false, "175.23.44.1;~171.\\d{1,3}\\.\\d{1,2}\\.\\d{1,3}  ");
+        LocalHostPermitHandler handler = new LocalHostPermitHandler(false, "175.23.44.1, 192.168.1.192/26  ");
         handler.handlerAdded(context);
         verify(context, never()).writeAndFlush(any());
     }
 
     @Test
-    void shouldNotShowIpNotPermittedMsg_GivenAcceptForeignIpFalseAndValidWhiteListRegex() throws Exception {
+    void shouldNotShowIpNotPermittedMsg_GivenAcceptForeignIpFalseAndMatchWhiteListRange() throws Exception {
         ChannelHandlerContext context = mock(ChannelHandlerContext.class);
         Channel channel = mock(Channel.class);
         when(context.channel()).thenReturn(channel);
         InetAddress addr = mock(InetAddress.class);
         when(addr.isLoopbackAddress()).thenReturn(false);
-        when(addr.getHostAddress()).thenReturn("171.33.21.6");
+        when(addr.getHostAddress()).thenReturn("192.168.1.199");
         InetSocketAddress address = new InetSocketAddress(addr, 12345);
         when(channel.remoteAddress()).thenReturn(address);
 
-        LocalHostPermitHandler handler = new LocalHostPermitHandler(false, "175.23.44.1; ~171.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}");
+        LocalHostPermitHandler handler = new LocalHostPermitHandler(false, "175.23.44.1, 192.168.1.192/26");
         handler.handlerAdded(context);
         verify(context, never()).writeAndFlush(any());
     }

--- a/dubbo-plugin/dubbo-qos/src/test/java/org/apache/dubbo/qos/server/handler/LocalHostPermitHandlerTest.java
+++ b/dubbo-plugin/dubbo-qos/src/test/java/org/apache/dubbo/qos/server/handler/LocalHostPermitHandlerTest.java
@@ -38,7 +38,7 @@ import static org.mockito.Mockito.when;
 
 class LocalHostPermitHandlerTest {
     @Test
-    void shouldShowIpNotPermitted_GivenAcceptForeignIpFalseAndEmptyWhiteList() throws Exception {
+    void shouldShowIpNotPermittedMsg_GivenAcceptForeignIpFalseAndEmptyWhiteList() throws Exception {
         ChannelHandlerContext context = mock(ChannelHandlerContext.class);
         Channel channel = mock(Channel.class);
         when(context.channel()).thenReturn(channel);
@@ -57,7 +57,7 @@ class LocalHostPermitHandlerTest {
     }
 
     @Test
-    void shouldShowIpNotPermitted_GivenAcceptForeignIpFalseAndInvalidWhiteList() throws Exception {
+    void shouldShowIpNotPermittedMsg_GivenAcceptForeignIpFalseAndInvalidWhiteList() throws Exception {
         ChannelHandlerContext context = mock(ChannelHandlerContext.class);
         Channel channel = mock(Channel.class);
         when(context.channel()).thenReturn(channel);
@@ -77,7 +77,7 @@ class LocalHostPermitHandlerTest {
     }
 
     @Test
-    void shouldNotShowIpNotPermitted_GivenAcceptForeignIpFalseAndValidWhiteList() throws Exception {
+    void shouldNotShowIpNotPermittedMsg_GivenAcceptForeignIpFalseAndValidWhiteList() throws Exception {
         ChannelHandlerContext context = mock(ChannelHandlerContext.class);
         Channel channel = mock(Channel.class);
         when(context.channel()).thenReturn(channel);
@@ -93,7 +93,7 @@ class LocalHostPermitHandlerTest {
     }
 
     @Test
-    void shouldNotShowIpNotPermitted_GivenAcceptForeignIpFalseAndValidWhiteListRegex() throws Exception {
+    void shouldNotShowIpNotPermittedMsg_GivenAcceptForeignIpFalseAndValidWhiteListRegex() throws Exception {
         ChannelHandlerContext context = mock(ChannelHandlerContext.class);
         Channel channel = mock(Channel.class);
         when(context.channel()).thenReturn(channel);

--- a/dubbo-plugin/dubbo-qos/src/test/java/org/apache/dubbo/qos/server/handler/QosProcessHandlerTest.java
+++ b/dubbo-plugin/dubbo-qos/src/test/java/org/apache/dubbo/qos/server/handler/QosProcessHandlerTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.dubbo.qos.server.handler;
 
+import org.apache.dubbo.common.utils.StringUtils;
 import org.apache.dubbo.rpc.model.FrameworkModel;
 
 import io.netty.buffer.ByteBuf;
@@ -42,7 +43,7 @@ class QosProcessHandlerTest {
         ChannelHandlerContext context = Mockito.mock(ChannelHandlerContext.class);
         ChannelPipeline pipeline = Mockito.mock(ChannelPipeline.class);
         Mockito.when(context.pipeline()).thenReturn(pipeline);
-        QosProcessHandler handler = new QosProcessHandler(FrameworkModel.defaultModel(), "welcome", false);
+        QosProcessHandler handler = new QosProcessHandler(FrameworkModel.defaultModel(), "welcome", false, StringUtils.EMPTY_STRING);
         handler.decode(context, buf, Collections.emptyList());
         verify(pipeline).addLast(any(HttpServerCodec.class));
         verify(pipeline).addLast(any(HttpObjectAggregator.class));
@@ -56,7 +57,7 @@ class QosProcessHandlerTest {
         ChannelHandlerContext context = Mockito.mock(ChannelHandlerContext.class);
         ChannelPipeline pipeline = Mockito.mock(ChannelPipeline.class);
         Mockito.when(context.pipeline()).thenReturn(pipeline);
-        QosProcessHandler handler = new QosProcessHandler(FrameworkModel.defaultModel(), "welcome", false);
+        QosProcessHandler handler = new QosProcessHandler(FrameworkModel.defaultModel(), "welcome", false, StringUtils.EMPTY_STRING);
         handler.decode(context, buf, Collections.emptyList());
         verify(pipeline).addLast(any(LineBasedFrameDecoder.class));
         verify(pipeline).addLast(any(StringDecoder.class));


### PR DESCRIPTION
## What is the purpose of the change
> Currently, Dubbo qos only support qosAcceptForeignIp and this will deny all of the foreign ips, we may need support foreign ip whitelist.

close #11014 


## Brief changelog

Support config `qos.accept.foreign.ip.whitelist` with `full match ip and escaped regex`, delimiter is `;`.  i.e.
`qos.accept.foreign.ip.whitelist=172.12.32.1;  ~175\\.\\d{1,3}\\.\\d{1,3}.\\d{1,3}`


## Verifying this change


<!-- Follow this checklist to help us incorporate your contribution quickly and easily: -->

## Checklist
- [x] Make sure there is a [GitHub_issue](https://github.com/apache/dubbo/issues) field for the change (usually before you start working on it). Trivial changes like typos do not require a GitHub issue. Your pull request should address just this issue, without pulling in other changes - one PR resolves one issue.
- [x] Each commit in the pull request should have a meaningful subject line and body.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Check if is necessary to patch to Dubbo 3 if you are work on Dubbo 2.7
- [x] Write necessary unit-test to verify your logic correction, more mock a little better when cross module dependency exist. If the new feature or significant change is committed, please remember to add sample in [dubbo samples](https://github.com/apache/dubbo-samples) project.
- [ ] Add some description to [dubbo-website](https://github.com/apache/dubbo-website) project if you are requesting to add a feature.
- [ ] GitHub Actions works fine on your own branch.
- [ ] If this contribution is large, please follow the [Software Donation Guide](https://github.com/apache/dubbo/wiki/Software-donation-guide).
